### PR TITLE
Problems with correlations

### DIFF
--- a/R/matchSegments.R
+++ b/R/matchSegments.R
@@ -33,6 +33,8 @@ for (index in 1:intSegLength)
         testSeg$centre<- intSegments$centre[index]
 
     peaksCompared<-comparePeaks(refSp, refSegments, intSp, testSeg, MAX_DIST_FACTOR, FALSE)
+    	
+    if (is.na(peaksCompared$rC)) peaksCompared$rC=0
 
     if ((peaksCompared$rC>MIN_RC) && (peaksCompared$rC!=0))
     {

--- a/R/recurAlign.R
+++ b/R/recurAlign.R
@@ -33,6 +33,7 @@ if (abs(lag) < length(testSegment))
     }
 
     CorrCoef<-corrcoef_aligned(refSegment,alignedTemp,recursion$step)
+    if (is.na(CorrCoef)) CorrCoef=0
 
     if (CorrCoef>=recursion$acceptance)
      {
@@ -54,6 +55,7 @@ CorrCoef<-corrcoef_aligned(refSegment,alignedSegment,recursion$step)
 
 # Can be adjusted the recursion stops if the resemblance between the
 # referebce and the segment of interest is e.g. 98%
+if (is.na(CorrCoef)) CorrCoef=0
 
 if (CorrCoef>=recursion$resamblance) 
 {return(alignedSegment)}


### PR DESCRIPTION
Dear Lyamine,

I am Daniel Canueto, PhD Student for Rovira i Virgili University. I am working in the automatic alignment and quantificaiton of urine NMR spectra through a NMR package. I find really interesting to build a dependency on your 'mQTL-NMR' package.

However, there is a bug in 'recurAlign' and 'matchSegments' function that makes the function crash when I try to implement it, becausae correlation can give sometimes NA results.

Furthermore, I would really appreciate if it were possible to have the information of how each peak has been shifted. I have tried to find this information analyzing the code, but I couldn't find how to get it. As a person more experienced in how the code is built, you may know where or how this info can be extracted. Then I would write a function that stores this information and share it with you, if you find this function interesting.

Thank you very much for the reply.

Best regards,

Daniel